### PR TITLE
Fixed decoding binary bulk strings containing \r

### DIFF
--- a/redis/proto/errors.go
+++ b/redis/proto/errors.go
@@ -22,6 +22,7 @@ const (
 	errorInvalidMessageType      = "invalid message type (%c)"
 	errorInvalidMessage          = "invalid message (%s)"
 	errorInvalidBulkStringLength = "invalid bulk string length (%d != %d)"
+	errorInvalidBulkStringDelim  = "invalid bulk string ending delimiter %s"
 )
 
 // ErrEOM is the error returned by Array::Next() when no more message is available.

--- a/redis/proto/parser.go
+++ b/redis/proto/parser.go
@@ -87,7 +87,7 @@ func (parser *Parser) nextLengthBytes(num int) ([]byte, error) {
 		}
 		totalRead += read
 	}
-	if (rune)(buf[num]) != cr || (rune)(buf[num+1]) != lf {
+	if buf[num] != cr || buf[num+1] != lf {
 		return nil, fmt.Errorf(errorInvalidBulkStringDelim, buf[num:n])
 	}
 	return buf[0:num], nil

--- a/redis/proto/parser.go
+++ b/redis/proto/parser.go
@@ -69,7 +69,31 @@ func (parser *Parser) nextLineBytes() ([]byte, error) {
 	return lenBytes, nil
 }
 
-// nextBulkMessage gets a next line bytes.
+// get next bulk message bytes of length num
+func (parser *Parser) nextLengthBytes(num int) ([]byte, error) {
+	n := num + 2 // + crlf
+	buf := make([]byte, n)
+	totalRead := 0
+	for totalRead < n {
+		read, err := parser.reader.Read(buf[totalRead:])
+		if err != nil {
+			if err == io.EOF {
+				if totalRead+read < n {
+					return nil, fmt.Errorf(errorInvalidBulkStringLength, totalRead+read, num)
+				}
+				break
+			}
+			return nil, err
+		}
+		totalRead += read
+	}
+	if (rune)(buf[num]) != cr || (rune)(buf[num+1]) != lf {
+		return nil, fmt.Errorf(errorInvalidBulkStringDelim, buf[num:n])
+	}
+	return buf[0:num], nil
+}
+
+// nextBulkMessage gets a next bulk string bytes.
 func (parser *Parser) nextBulkMessage() (*Message, error) {
 	numBytes, err := parser.nextLineBytes()
 	if err != nil {
@@ -88,12 +112,9 @@ func (parser *Parser) nextBulkMessage() (*Message, error) {
 		return msg, nil
 	}
 
-	msg.bytes, err = parser.nextLineBytes()
+	msg.bytes, err = parser.nextLengthBytes(num)
 	if err != nil {
 		return nil, err
-	}
-	if len(msg.bytes) != num {
-		return msg, fmt.Errorf(errorInvalidBulkStringLength, len(msg.bytes), num)
 	}
 	return msg, nil
 }


### PR DESCRIPTION
Hi Satoshi!

I've found that proto/parser incorrectly parses binary strings. The problem is that parser stops on `\r` character, but this is absolutely valid character in a bulk string like any other byte. When parsing bulk string only length bytes should be considered, and just last two bytes should be `\r\n`

You can easily reproduce the error using redis-cli as follows:
```
> set a "\r"
``` 

Or even key may contain `\r` or any other byte
```
> set "\r" "\r"
```

I've changed bulk string parsing logic and added some tests. Additionally I've added option to check expected errors to be able to test error cases.